### PR TITLE
Remove name column, put name above comment

### DIFF
--- a/email.go
+++ b/email.go
@@ -52,7 +52,7 @@ func Email() string {
 	notesTemplate, err := template.ParseFiles("template.html")
 	check(err)
 
-	today := time.Now().Add(-8 * time.Hour).Format("Monday January 2, 2006")
+	today := time.Now().Add(-8 * time.Hour).Format("Monday, January 2, 2006")
 	variables := Variables{today, notesByCategory()}
 	err = notesTemplate.Execute(&html, variables)
 	check(err)

--- a/template.html
+++ b/template.html
@@ -30,13 +30,11 @@
                     <table border="0" cellspacing="0" cellpadding="0" class="bodyContent" style="margin: 0;padding: 0;width: 100%;border-collapse: separate !important;">
                     {{range .Notes}}
                       <tr>
-                        <td align="left" valign="top" width="40" style="border-bottom: 1px solid #ddd;padding: 1em 0 1em 0;">
-                          <img src="{{.AvatarURL}}" height="32" width="32" style="border: 0;border-radius: 3px;display: block;">
-                        </td>
-                        <td align="left" valign="top" width="100" style="border-bottom: 1px solid #ddd;padding: 1em 0 1em 0;">
-                          <strong>{{.AbbreviatedAuthor}}</strong>
+                        <td align="left" valign="top" width="72" style="border-bottom: 1px solid #ddd;padding: 1em 0 1em 0;">
+                          <img src="{{.AvatarURL}}" height="48" width="48" style="border: 0;border-radius: 48px;display: block;">
                         </td>
                         <td align="left" valign="top" style="border-bottom: 1px solid #ddd;padding: 1em 0 1em 0;">
+                          <div style="padding: 0 0 0.5em 0;"><strong>{{.AbbreviatedAuthor}}</strong></div>
                           {{.Text}}
                         </td>
                       </tr>


### PR DESCRIPTION
@jasondew This should be a lot more readable now!

One extra thing we can do now is not abbreviate the author's name, since we have the extra space. If you want to make that change, you can just merge and deploy when you're good to go.
