### PR TITLE
Add send_digest to Final Steps in Heroku

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
         <ul>
           <li>Fill in the remaining fields of the Heroku form. Enter the email you want the daily digests to get sent to in the <strong>TO_EMAIL</strong> field. Provide a <strong>TO_NAME</strong> for the email. Similarly, enter in the email address you would like the email to be sent from and the name of that in <strong>FROM_EMAIL</strong> and <strong>FROM_NAME</strong>.</li>
           <li>Click <strong>Deploy for Free</strong> in Heroku.</li>
-          <li>To setup the daily emails, click <strong>Heroku Scheduler</strong>. Click <strong>Add new job</strong> and indicate the name of the job, and frequency and time you would like the email to be sent at. </li>
+          <li>To setup the daily emails, click <strong>Heroku Scheduler</strong>. Click <strong>Add new job</strong> and indicate the name of the job, and frequency and time you would like the email to be sent at. Set the Heroku scheduler task to be **SEND_DIGEST**.</code> </li>
           <li>Lastly, take the URL of your app from under <strong>Settings</strong> in Heroku and copy this into the <strong>URL</strong> field of your Slack <strong>Slash Commands</strong> page. If your app name is <strong>heroku-notable-test</strong> in Heroku, then your URL will be <code>https://heroku-notable-test.herokuapp.com/notes</code>.</li>
             <p><img src="https://monosnap.com/file/lbJX75IwmffXgfuG6qquAsEBGiJ8ol.png" alt="" width="480"></p>
           <li>Fill out the rest of the <strong>Slash Commands</strong> page fields in Slack as you wish and click <strong>Save Integration</strong>.</li>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
         <ul>
           <li>Fill in the remaining fields of the Heroku form. Enter the email you want the daily digests to get sent to in the <strong>TO_EMAIL</strong> field. Provide a <strong>TO_NAME</strong> for the email. Similarly, enter in the email address you would like the email to be sent from and the name of that in <strong>FROM_EMAIL</strong> and <strong>FROM_NAME</strong>.</li>
           <li>Click <strong>Deploy for Free</strong> in Heroku.</li>
-          <li>To setup the daily emails, click <strong>Heroku Scheduler</strong>. Click <strong>Add new job</strong> and indicate the name of the job, and frequency and time you would like the email to be sent at. Set the Heroku scheduler task to be **SEND_DIGEST**.</code> </li>
+          <li>To setup the daily emails, click <strong>Heroku Scheduler</strong>. Click <strong>Add new job</strong> and indicate the name of the job, and frequency and time you would like the email to be sent at. Set the Heroku scheduler task to be <code>send_digest</code>.</li>
           <li>Lastly, take the URL of your app from under <strong>Settings</strong> in Heroku and copy this into the <strong>URL</strong> field of your Slack <strong>Slash Commands</strong> page. If your app name is <strong>heroku-notable-test</strong> in Heroku, then your URL will be <code>https://heroku-notable-test.herokuapp.com/notes</code>.</li>
             <p><img src="https://monosnap.com/file/lbJX75IwmffXgfuG6qquAsEBGiJ8ol.png" alt="" width="480"></p>
           <li>Fill out the rest of the <strong>Slash Commands</strong> page fields in Slack as you wish and click <strong>Save Integration</strong>.</li>


### PR DESCRIPTION
@jasondew This adds a note about setting the Heroku scheduler task to be SEND_DIGEST based on the feedback in [this ticket](https://iridesco.zendesk.com/agent/tickets/201391). Is this the right place to add it?